### PR TITLE
Support node v18 and drop node v12

### DIFF
--- a/.github/workflows/ci-module.yml
+++ b/.github/workflows/ci-module.yml
@@ -10,3 +10,5 @@ on:
 jobs:
   test:
     uses: hapijs/.github/.github/workflows/ci-module.yml@master
+    with:
+      min-node-version: 14

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,5 @@
-Copyright (c) 2012-2020, Sideway Inc, and project contributors  
+Copyright (c) 2012-2022, Project contributors
+Copyright (c) 2012-2020, Sideway Inc
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/lib/index.js
+++ b/lib/index.js
@@ -175,8 +175,8 @@ internals.normalizePassword = function (password) {
 
         return {
             id: password.id,
-            encryption: password.secret || password.encryption,
-            integrity: password.secret || password.integrity
+            encryption: password.secret ?? password.encryption,
+            integrity: password.secret ?? password.integrity
         };
     }
 
@@ -195,7 +195,7 @@ exports.seal = async function (object, password, options) {
 
     options = Object.assign({}, options);       // Shallow cloned to prevent changes during async operations
 
-    const now = Date.now() + (options.localtimeOffsetMsec || 0);                 // Measure now before any other processing
+    const now = Date.now() + (options.localtimeOffsetMsec ?? 0);                 // Measure now before any other processing
 
     // Serialize object
 
@@ -246,7 +246,7 @@ exports.unseal = async function (sealed, password, options) {
 
     options = Object.assign({}, options);                                       // Shallow cloned to prevent changes during async operations
 
-    const now = Date.now() + (options.localtimeOffsetMsec || 0);                // Measure now before any other processing
+    const now = Date.now() + (options.localtimeOffsetMsec ?? 0);                // Measure now before any other processing
 
     // Break string into components
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@hapi/hoek": "^10.0.0",
-    "@hapi/b64": "^5.0.0",
+    "@hapi/b64": "^6.0.0",
     "@hapi/boom": "^10.0.0",
     "@hapi/bourne": "^3.0.0",
     "@hapi/cryptiles": "^6.0.0"

--- a/package.json
+++ b/package.json
@@ -19,17 +19,18 @@
     ]
   },
   "dependencies": {
-    "@hapi/hoek": "9.x.x",
-    "@hapi/b64": "5.x.x",
-    "@hapi/boom": "9.x.x",
-    "@hapi/bourne": "2.x.x",
-    "@hapi/cryptiles": "5.x.x"
+    "@hapi/hoek": "^10.0.0",
+    "@hapi/b64": "^5.0.0",
+    "@hapi/boom": "^10.0.0",
+    "@hapi/bourne": "^3.0.0",
+    "@hapi/cryptiles": "^6.0.0"
   },
   "devDependencies": {
-    "@hapi/code": "8.x.x",
+    "@hapi/code": "^9.0.0",
     "@hapi/eslint-plugin": "*",
-    "@hapi/lab": "24.x.x",
-    "typescript": "~4.0.2"
+    "@hapi/lab": "^25.0.1",
+    "@types/node": "^17.0.31",
+    "typescript": "~4.6.4"
   },
   "scripts": {
     "test": "lab -a @hapi/code -t 100 -L -Y",

--- a/test/esm.js
+++ b/test/esm.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const Code = require('@hapi/code');
+const Lab = require('@hapi/lab');
+
+
+const { before, describe, it } = exports.lab = Lab.script();
+const expect = Code.expect;
+
+
+describe('import()', () => {
+
+    let Ion;
+
+    before(async () => {
+
+        Ion = await import('../lib/index.js');
+    });
+
+    it('exposes all methods and classes as named imports', () => {
+
+        expect(Object.keys(Ion)).to.equal([
+            'algorithms',
+            'decrypt',
+            'default',
+            'defaults',
+            'encrypt',
+            'generateKey',
+            'hmacWithPassword',
+            'macFormatVersion',
+            'macPrefix',
+            'seal',
+            'unseal'
+        ]);
+    });
+});

--- a/test/index.js
+++ b/test/index.js
@@ -59,6 +59,19 @@ describe('Iron', () => {
         expect(unsealed).to.equal(obj);
     });
 
+    it('unseal and sealed object without time offset', async () => {
+
+        const options = Hoek.clone(Iron.defaults);
+        options.ttl = 200;
+        delete options.localtimeOffsetMsec;
+        const sealed = await Iron.seal(obj, password, options);
+
+        const options2 = Hoek.clone(Iron.defaults);
+        delete options2.localtimeOffsetMsec;
+        const unsealed = await Iron.unseal(sealed, { 'default': password }, options2);
+        expect(unsealed).to.equal(obj);
+    });
+
     it('turns object into a ticket than parses the ticket successfully (password buffer)', async () => {
 
         const key = Cryptiles.randomBits(256);


### PR DESCRIPTION
 - Test on node v14+.
 - Update to node v18-compatible versions of hapi modules, update typescript.

If this looks good, this will go out as iron v7.