### PR TITLE
chore: bump hoek

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,16 +19,16 @@
     ]
   },
   "dependencies": {
-    "@hapi/hoek": "^10.0.0",
-    "@hapi/b64": "^6.0.0",
-    "@hapi/boom": "^10.0.0",
+    "@hapi/hoek": "^11.0.2",
+    "@hapi/b64": "^6.0.1",
+    "@hapi/boom": "^10.0.1",
     "@hapi/bourne": "^3.0.0",
-    "@hapi/cryptiles": "^6.0.0"
+    "@hapi/cryptiles": "^6.0.1"
   },
   "devDependencies": {
-    "@hapi/code": "^9.0.0",
+    "@hapi/code": "^9.0.3",
     "@hapi/eslint-plugin": "*",
-    "@hapi/lab": "^25.0.1",
+    "@hapi/lab": "^25.1.2",
     "@types/node": "^17.0.31",
     "typescript": "~4.6.4"
   },


### PR DESCRIPTION
Needs https://github.com/hapijs/b64/pull/41, https://github.com/hapijs/boom/pull/299, https://github.com/hapijs/bounce/pull/35 and a new release of cryptiles before merging/releasing.